### PR TITLE
added encryption in-transit support

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -122,6 +122,7 @@ resource "aws_elasticache_cluster" "default" {
   availability_zone            = var.availability_zone
   preferred_availability_zones = var.availability_zones
   tags                         = module.this.tags
+  transit_encryption_enabled   = var.transit_encryption_enabled
 }
 
 #

--- a/variables.tf
+++ b/variables.tf
@@ -131,3 +131,9 @@ variable "cloudwatch_metric_alarms_enabled" {
   description = "Boolean flag to enable/disable CloudWatch metrics alarms"
   default     = false
 }
+
+variable "transit_encryption_enabled" {
+  type        = bool
+  description = "Enable encryption in-transit. Supported only with Memcached versions 1.6.12 and later, running in a VPC"
+  default     = false
+}


### PR DESCRIPTION
Enable encryption in-transit. Supported only with Memcached versions 1.6.12 and later, running in a VPC
